### PR TITLE
chore: Remove labels, type, and projects from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -2,9 +2,6 @@
 name: "Bug report \U0001F41B"
 description: Report errors or unexpected behavior
 title: 'Bug: '
-labels: ['needs triage :wave:', 'bug :beetle:']
-type: 'bug'
-projects: ['msc365/3']
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -2,9 +2,6 @@
 name: "Feature request \U0001F680"
 description: 'Suggest an idea for this project'
 title: '[Request] '
-labels: ['needs triage :wave:', 'enhancement :sparkles:']
-type: 'feature'
-projects: ['msc365/3']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-miscellaneous.yml
+++ b/.github/ISSUE_TEMPLATE/03-miscellaneous.yml
@@ -2,9 +2,6 @@
 name: "Miscellaneous work \U0001F6E0"
 description: 'Create a task for miscellaneous work'
 title: '[Miscellaneous] '
-labels: ['needs triage :wave:', 'miscellaneous :hammer_and_wrench:']
-type: 'task'
-projects: ['msc365/3']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
- chore: Remove labels, type, and projects from issue templates for simplification