### PR TITLE
chore: Using namespace System.Collections.Generic declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ All notable changes to this project will be documented in this file.
 
 <br> -->
 
+## [UNRELEASED]
+
+### What's Changed
+- chore: Using namespace `System.Collections.Generic` declaration at the module root
+
+### Breaking Changes
+- _None_
+
+<br>
+
 ## [0.3.0] - 2026-02-05
 
 ### Summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ To make life a bit easier, a `.vscode/settings.json` file is configured to enfor
 - Take notice of the [PowerShell development guidelines](https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/strongly-encouraged-development-guidelines) when you write modules or cmdlets.
 - Take notice of the [PowerShell-Docs](https://learn.microsoft.com/en-us/powershell/scripting/community/contributing/powershell-style-guide) style guide when you write documentation content.
 - Use [PlatyPS](src/PlatyPS.ps1) script with care. Do _NOT_ overwrite current docs, use a `tmp` directory to create your doc file, then adjust to align with reference documentation.
+- Typed helper collections should use `[List[T]]::new()` so we can reuse small mutable lists across pagination loops without re-qualifying `System.Collections.Generic`.
+  
+  > Collections are supported via the module-wide `using namespace System.Collections.Generic`.
 
 ## Conventional commits
 

--- a/src/Azure.DevOps.PSModule/Azure.DevOps.PSModule.psm1
+++ b/src/Azure.DevOps.PSModule/Azure.DevOps.PSModule.psm1
@@ -1,4 +1,7 @@
-﻿[CmdletBinding()]
+﻿# Using statements
+using namespace System.Collections.Generic
+
+[CmdletBinding()]
 param()
 
 Write-Verbose $PSScriptRoot

--- a/src/Azure.DevOps.PSModule/Public/Core/Projects/Get-AdoProject.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Core/Projects/Get-AdoProject.ps1
@@ -112,7 +112,7 @@
 
     process {
         try {
-            $queryParameters = [System.Collections.Generic.List[string]]::new()
+            $queryParameters = [List[string]]::new()
 
             if ($Name) {
                 $uri = "$CollectionUri/_apis/projects/$Name"
@@ -150,7 +150,7 @@
                 $continuationToken = $null
 
                 do {
-                    $pagedParams = [System.Collections.Generic.List[string]]::new()
+                    $pagedParams = [List[string]]::new()
 
                     if ($queryParameters.Count) {
                         $pagedParams.AddRange($queryParameters)

--- a/src/Azure.DevOps.PSModule/Public/Core/Teams/Get-AdoTeam.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Core/Teams/Get-AdoTeam.ps1
@@ -117,7 +117,7 @@
     process {
         try {
 
-            $queryParameters = [System.Collections.Generic.List[string]]::new()
+            $queryParameters = [List[string]]::new()
 
             if ($Name) {
                 $uri = "$CollectionUri/_apis/projects/$ProjectName/teams/$Name"

--- a/src/Azure.DevOps.PSModule/Public/Git/Repositories/Get-AdoRepository.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Git/Repositories/Get-AdoRepository.ps1
@@ -94,7 +94,7 @@
 
     process {
         try {
-            $queryParameters = [System.Collections.Generic.List[string]]::new()
+            $queryParameters = [List[string]]::new()
 
             if ($Name) {
                 $uri = "$CollectionUri/$ProjectName/_apis/git/repositories/$Name"

--- a/src/Azure.DevOps.PSModule/Public/Git/Repositories/New-AdoRepository.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Git/Repositories/New-AdoRepository.ps1
@@ -83,7 +83,7 @@
                 if (-not $projectId) { continue }
             }
 
-            $queryParameters = [System.Collections.Generic.List[string]]::new()
+            $queryParameters = [List[string]]::new()
 
             if ($SourceRef) {
                 $queryParameters.Add("sourceRef=$SourceRef")

--- a/src/Azure.DevOps.PSModule/Public/Graph/Groups/Get-AdoGroup.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Graph/Groups/Get-AdoGroup.ps1
@@ -118,7 +118,7 @@
 
     process {
         try {
-            $queryParameters = [System.Collections.Generic.List[string]]::new()
+            $queryParameters = [List[string]]::new()
 
             if ($GroupDescriptor) {
                 $uri = "$CollectionUri/_apis/graph/groups/$GroupDescriptor"
@@ -145,7 +145,7 @@
                 $continuationToken = $null
 
                 do {
-                    $pagedParams = [System.Collections.Generic.List[string]]::new()
+                    $pagedParams = [List[string]]::new()
 
                     if ($queryParameters.Count) {
                         $pagedParams.AddRange($queryParameters)

--- a/src/Azure.DevOps.PSModule/Public/MemberEntitlementManagement/UserEntitlements/Get-AdoUserEntitlement.ps1
+++ b/src/Azure.DevOps.PSModule/Public/MemberEntitlementManagement/UserEntitlements/Get-AdoUserEntitlement.ps1
@@ -107,7 +107,7 @@
 
     process {
         try {
-            $queryParameters = [System.Collections.Generic.List[string]]::new()
+            $queryParameters = [List[string]]::new()
 
             if ($UserId) {
                 $uri = "$CollectionUri/_apis/userentitlements/$UserId"
@@ -140,7 +140,7 @@
                 $continuationToken = $null
 
                 do {
-                    $pagedParams = [System.Collections.Generic.List[string]]::new()
+                    $pagedParams = [List[string]]::new()
 
                     if ($queryParameters.Count) {
                         $pagedParams.AddRange($queryParameters)

--- a/src/Azure.DevOps.PSModule/Public/Pipeline/Check/Configuration/Get-AdoCheckConfiguration.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Pipeline/Check/Configuration/Get-AdoCheckConfiguration.ps1
@@ -146,8 +146,8 @@
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
-            $DefinitionRefIds = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
+            $DefinitionRefIds = [List[string]]::new()
 
             if ($id) {
                 $uri = "$CollectionUri/$ProjectName/_apis/pipelines/checks/configurations/$id"

--- a/src/Azure.DevOps.PSModule/Public/Pipeline/Environment/Get-AdoEnvironment.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Pipeline/Environment/Get-AdoEnvironment.ps1
@@ -102,7 +102,7 @@
 
     process {
         try {
-            $QueryParameters = [system.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
 
             if ($Id) {
                 $uri = "$CollectionUri/$ProjectName/_apis/pipelines/environments/$Id"
@@ -133,7 +133,7 @@
                 $continuationToken = $null
 
                 do {
-                    $pagedParams = [System.Collections.Generic.List[string]]::new()
+                    $pagedParams = [List[string]]::new()
 
                     if ($QueryParameters.Count) {
                         $pagedParams.AddRange($QueryParameters)

--- a/src/Azure.DevOps.PSModule/Public/Policy/Configurations/Get-AdoPolicyConfiguration.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Policy/Configurations/Get-AdoPolicyConfiguration.ps1
@@ -123,7 +123,7 @@
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
 
             if ($Id) {
                 $uri = "$CollectionUri/$ProjectName/_apis/policy/configurations/$Id"
@@ -153,7 +153,7 @@
                 $continuationToken = $null
 
                 do {
-                    $pagedParams = [System.Collections.Generic.List[string]]::new()
+                    $pagedParams = [List[string]]::new()
 
                     if ($QueryParameters.Count) {
                         $pagedParams.AddRange($QueryParameters)

--- a/src/Azure.DevOps.PSModule/Public/ServiceEndpoint/EndPoints/Get-AdoServiceEndpoint.ps1
+++ b/src/Azure.DevOps.PSModule/Public/ServiceEndpoint/EndPoints/Get-AdoServiceEndpoint.ps1
@@ -113,7 +113,7 @@
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
             if ($PSCmdlet.ParameterSetName -eq 'ByIds') {
                 if ($Ids) {
                     $QueryParameters.Add("endpointIds=$($Ids -join ',')")

--- a/src/Azure.DevOps.PSModule/Public/ServiceEndpoint/EndPoints/Remove-AdoServiceEndpoint.ps1
+++ b/src/Azure.DevOps.PSModule/Public/ServiceEndpoint/EndPoints/Remove-AdoServiceEndpoint.ps1
@@ -72,7 +72,7 @@
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
             $QueryParameters.Add("projectIds=$($ProjectIds -join ',')")
 
             if ($Deep.IsPresent) {

--- a/src/Azure.DevOps.PSModule/Public/Work/TeamSettings/Iterations/Get-AdoTeamIteration.ps1
+++ b/src/Azure.DevOps.PSModule/Public/Work/TeamSettings/Iterations/Get-AdoTeamIteration.ps1
@@ -108,7 +108,7 @@ function Get-AdoTeamIteration {
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
 
             if ($Id) {
                 # Get specific iteration by ID

--- a/src/Azure.DevOps.PSModule/Public/WorkItemTracking/ClassificationNodes/Get-AdoClassificationNode.ps1
+++ b/src/Azure.DevOps.PSModule/Public/WorkItemTracking/ClassificationNodes/Get-AdoClassificationNode.ps1
@@ -141,7 +141,7 @@ function Get-AdoClassificationNode {
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
 
             $uri = "$CollectionUri/$ProjectName/_apis/wit/classificationnodes"
 

--- a/src/Azure.DevOps.PSModule/Public/WorkItemTracking/ClassificationNodes/Remove-AdoClassificationNode.ps1
+++ b/src/Azure.DevOps.PSModule/Public/WorkItemTracking/ClassificationNodes/Remove-AdoClassificationNode.ps1
@@ -107,7 +107,7 @@ function Remove-AdoClassificationNode {
 
     process {
         try {
-            $QueryParameters = [System.Collections.Generic.List[string]]::new()
+            $QueryParameters = [List[string]]::new()
 
             if ($ReclassifyId) {
                 $QueryParameters.Add("`$reclassifyId=$ReclassifyId")


### PR DESCRIPTION
Using namespace System.Collections.Generic declaration at the module root, so that each function can call [List[string]::new()] instead of the more verbose [System.Collections.Generic.List[string]]::new()